### PR TITLE
Feature 유저별/그룹별 일간 습관 목록 조회 api

### DIFF
--- a/src/controllers/groupController.js
+++ b/src/controllers/groupController.js
@@ -1,0 +1,15 @@
+const groupService = require('../services/groupService');
+
+const getGroupDailyHabitList = async (req, res, next) => {
+  try {
+    const memberDailyHabits = await groupService.getMemberDailyHabits(req);
+
+    return res.status(200).json({ data: memberDailyHabits });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+module.exports = {
+  getGroupDailyHabitList,
+};

--- a/src/controllers/habitController.js
+++ b/src/controllers/habitController.js
@@ -41,8 +41,8 @@ const createHabit = async (req, res, next) => {
       doDay: { $in: doDay },
       habitStartDate: { $lte: habitEndDate },
       habitEndDate: { $gte: habitStartDate },
-      startTime: { $lte: endTime },
-      endTime: { $gte: startTime },
+      startTime: { $lt: endTime },
+      endTime: { $gt: startTime },
     });
 
     if (duplicateHabitTime) {
@@ -104,8 +104,8 @@ const updateHabit = async (req, res, next) => {
         doDay: { $in: doDay || habit.doDay },
         habitStartDate: { $lte: habitEndDate || habit.habitEndDate },
         habitEndDate: { $gte: habitStartDate || habit.habitStartDate },
-        startTime: { $lte: endTime || habit.endTime },
-        endTime: { $gte: startTime || habit.startTime },
+        startTime: { $lt: endTime || habit.endTime },
+        endTime: { $gt: startTime || habit.startTime },
       });
 
       if (duplicateHabitTime && String(duplicateHabitTime._id) !== habitId) {

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,4 +1,9 @@
+const { ERRORS } = require('../lib/ERRORS');
+const handleError = require('../lib/handleError');
+const Habit = require('../models/Habit');
+const User = require('../models/User');
 const userService = require('../services/userService');
+const dateToDay = require('../utils/dateToDay');
 
 const getUserCheck = async (req, res, next) => {
   const { email } = req.query;
@@ -18,6 +23,36 @@ const getUserCheck = async (req, res, next) => {
   }
 };
 
+const getUserDailyHabitList = async (req, res, next) => {
+  const { date } = req.query;
+  const { nickname } = req.params;
+  const dailyHabitList = { nickname: [] };
+  const currentDay = dateToDay(date);
+
+  try {
+    const user = await User.findOne({ nickname }).lean().exec();
+
+    if (!user) {
+      return handleError(res, ERRORS.USER_NOT_FOUND);
+    }
+
+    dailyHabitList.nickname = await Habit.find(
+      {
+        creator: user._id,
+        doDay: { $in: [currentDay] },
+        habitStartDate: { $lte: date },
+        habitEndDate: { $gte: date },
+      },
+      '_id habitTitle startTime endTime',
+    );
+
+    return res.status(200).json({ data: dailyHabitList });
+  } catch (error) {
+    return next(error);
+  }
+};
+
 module.exports = {
   getUserCheck,
+  getUserDailyHabitList,
 };

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,6 +1,5 @@
 const { ERRORS } = require('../lib/ERRORS');
 const handleError = require('../lib/handleError');
-const Habit = require('../models/Habit');
 const User = require('../models/User');
 const userService = require('../services/userService');
 const dateToDay = require('../utils/dateToDay');
@@ -26,27 +25,27 @@ const getUserCheck = async (req, res, next) => {
 const getUserDailyHabitList = async (req, res, next) => {
   const { date } = req.query;
   const { nickname } = req.params;
-  const dailyHabitList = { nickname: [] };
   const currentDay = dateToDay(date);
 
   try {
-    const user = await User.findOne({ nickname }).lean().exec();
+    const user = await User.findOne({ nickname })
+      .populate({
+        path: 'habits',
+        match: {
+          doDay: { $in: [currentDay] },
+          habitStartDate: { $lte: date },
+          habitEndDate: { $gte: date },
+        },
+        select: '_id habitTitle startTime endTime',
+      })
+      .lean()
+      .exec();
 
     if (!user) {
       return handleError(res, ERRORS.USER_NOT_FOUND);
     }
 
-    dailyHabitList.nickname = await Habit.find(
-      {
-        creator: user._id,
-        doDay: { $in: [currentDay] },
-        habitStartDate: { $lte: date },
-        habitEndDate: { $gte: date },
-      },
-      '_id habitTitle startTime endTime',
-    );
-
-    return res.status(200).json({ data: dailyHabitList });
+    return res.status(200).json({ data: { nickname: user.habits } });
   } catch (error) {
     return next(error);
   }

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,8 +1,6 @@
 const { ERRORS } = require('../lib/ERRORS');
 const handleError = require('../lib/handleError');
-const User = require('../models/User');
 const userService = require('../services/userService');
-const dateToDay = require('../utils/dateToDay');
 
 const getUserCheck = async (req, res, next) => {
   const { email } = req.query;
@@ -23,29 +21,16 @@ const getUserCheck = async (req, res, next) => {
 };
 
 const getUserDailyHabitList = async (req, res, next) => {
-  const { date } = req.query;
   const { nickname } = req.params;
-  const currentDay = dateToDay(date);
 
   try {
-    const user = await User.findOne({ nickname })
-      .populate({
-        path: 'habits',
-        match: {
-          doDay: { $in: [currentDay] },
-          habitStartDate: { $lte: date },
-          habitEndDate: { $gte: date },
-        },
-        select: '_id habitTitle startTime endTime',
-      })
-      .lean()
-      .exec();
+    const userDailyHabits = await userService.getUserDailyHabits(req, nickname);
 
-    if (!user) {
+    if (!userDailyHabits) {
       return handleError(res, ERRORS.USER_NOT_FOUND);
     }
 
-    return res.status(200).json({ data: { nickname: user.habits } });
+    return res.status(200).json({ data: { [nickname]: userDailyHabits } });
   } catch (error) {
     return next(error);
   }

--- a/src/lib/getLoginUserId.js
+++ b/src/lib/getLoginUserId.js
@@ -3,11 +3,9 @@ const { ERRORS } = require('./ERRORS');
 
 const getLoginUserId = (req) => {
   const token = req.cookies.accessToken;
-  console.log(req);
 
   try {
     const decoded = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
-    console.log(decoded);
     return decoded;
   } catch (error) {
     throw new Error(ERRORS.NEED_TOKEN);

--- a/src/lib/getLoginUserId.js
+++ b/src/lib/getLoginUserId.js
@@ -1,0 +1,17 @@
+const jwt = require('jsonwebtoken');
+const { ERRORS } = require('./ERRORS');
+
+const getLoginUserId = (req) => {
+  const token = req.cookies.accessToken;
+  console.log(req);
+
+  try {
+    const decoded = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
+    console.log(decoded);
+    return decoded;
+  } catch (error) {
+    throw new Error(ERRORS.NEED_TOKEN);
+  }
+};
+
+module.exports = getLoginUserId;

--- a/src/loaders/routes.js
+++ b/src/loaders/routes.js
@@ -1,9 +1,11 @@
 const authRouter = require('../routes/auth');
 const userRouter = require('../routes/user');
 const habitRouter = require('../routes/habit');
+const groupRouter = require('../routes/group');
 
 module.exports = (app) => {
   app.use('/api/auth', authRouter);
   app.use('/api/user', userRouter);
   app.use('/api/habit', habitRouter);
+  app.use('/api/group', groupRouter);
 };

--- a/src/middlewares/validateGroup.js
+++ b/src/middlewares/validateGroup.js
@@ -1,0 +1,14 @@
+const { param, query } = require('express-validator');
+const { ERRORS } = require('../lib/ERRORS');
+
+const validateGetGroupHabitList = [
+  param('groupId').isMongoId().withMessage(ERRORS.INVALID_MONGO_ID.MESSAGE),
+  query('date')
+    .optional()
+    .matches(/^\d{4}-\d{2}-\d{2}$/)
+    .withMessage(ERRORS.INVALID_HABIT_START_DATE_FORMAT),
+];
+
+module.exports = {
+  validateGetGroupHabitList,
+};

--- a/src/middlewares/validateUser.js
+++ b/src/middlewares/validateUser.js
@@ -1,4 +1,4 @@
-const { param, check } = require('express-validator');
+const { param, check, query } = require('express-validator');
 const { ERRORS } = require('../lib/ERRORS');
 
 const validateGetUser = [
@@ -38,4 +38,25 @@ const validateGetUserCheck = [
     .withMessage(ERRORS.EMAIL_INVALID),
 ];
 
-module.exports = { validateGetUser, validateCreateUser, validateGetUserCheck };
+const validateGetUserHabitList = [
+  param('nickname')
+    .isString()
+    .withMessage(ERRORS.INVALID_NICKNAME.MESSAGE)
+    .custom((value) => {
+      if (!/^[a-zA-Z0-9]+$/.test(value)) {
+        throw new Error(ERRORS.NICKNAME_NO_BLANK_CONTAINED);
+      }
+      return true;
+    }),
+  query('date')
+    .optional()
+    .matches(/^\d{4}-\d{2}-\d{2}$/)
+    .withMessage(ERRORS.INVALID_HABIT_START_DATE_FORMAT),
+];
+
+module.exports = {
+  validateGetUser,
+  validateCreateUser,
+  validateGetUserCheck,
+  validateGetUserHabitList,
+};

--- a/src/middlewares/verifyGroupMember.js
+++ b/src/middlewares/verifyGroupMember.js
@@ -1,0 +1,26 @@
+const { ERRORS } = require('../lib/ERRORS');
+const getLoginUserId = require('../lib/getLoginUserId');
+const handleError = require('../lib/handleError');
+const Group = require('../models/Group');
+
+const verifyGroupMember = (req, res, next) => {
+  const { groupId } = req.params;
+  const userId = getLoginUserId(req);
+
+  try {
+    const group = Group.findById(groupId).lean().exec();
+
+    if (!group) {
+      return handleError(res, ERRORS.GROUP_NOT_FOUND);
+    }
+
+    if (!group.members.includes(userId)) {
+      return handleError(res, ERRORS.USER_NOT_FOUND);
+    }
+    return next();
+  } catch (error) {
+    return handleError(res, ERRORS.INTERNAL_SERVER_ERROR);
+  }
+};
+
+module.exports = verifyGroupMember;

--- a/src/routes/group.js
+++ b/src/routes/group.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const commonErrorHandler = require('../middlewares/commonErrorHandler');
+const validateGroup = require('../middlewares/validateGroup');
+const validateMiddleware = require('../middlewares/validateMiddleware');
+const groupController = require('../controllers/groupController');
+
+const router = express.Router();
+
+/**
+ * 그룹별 일간 습관 목록 조회 API
+ * api/group/:groupId/habitList?date=:date
+ */
+router.get(
+  '/:groupId/habitList',
+  validateGroup.validateGetGroupHabitList,
+  validateMiddleware,
+  groupController.getGroupDailyHabitList,
+);
+
+router.use(commonErrorHandler);
+
+module.exports = router;

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -76,6 +76,17 @@ router.post(
   },
 );
 
+/**
+ * 유저별 일간 습관 목록 조회 API
+ * api/user/:nickname/habitList?date=:date
+ */
+router.get(
+  '/:nickname/habitList',
+  validateUser.validateGetUserHabitList,
+  validateMiddleware,
+  userController.getUserDailyHabitList,
+);
+
 router.use(commonErrorHandler);
 
 module.exports = router;

--- a/src/services/groupService.js
+++ b/src/services/groupService.js
@@ -1,0 +1,28 @@
+const Group = require('../models/Group');
+const userService = require('./userService');
+
+const getMemberDailyHabits = async (req) => {
+  const { groupId } = req.params;
+
+  const group = await Group.findOne({ _id: groupId })
+    .populate({
+      path: 'members',
+      select: 'nickname',
+    })
+    .lean()
+    .exec();
+
+  const memberDailyHabits = await Promise.all(
+    group.members.map(async ({ nickname }) => {
+      const userDailyHabits = await userService.getUserDailyHabits(
+        req,
+        nickname,
+      );
+      return { [nickname]: userDailyHabits };
+    }),
+  );
+
+  return memberDailyHabits;
+};
+
+module.exports = { getMemberDailyHabits };

--- a/src/services/groupService.js
+++ b/src/services/groupService.js
@@ -22,7 +22,13 @@ const getMemberDailyHabits = async (req) => {
     }),
   );
 
-  return memberDailyHabits;
+  const formattedDate = memberDailyHabits.reduce((acc, habit) => {
+    const [nickname] = Object.keys(habit);
+    acc[nickname] = habit[nickname];
+    return acc;
+  }, {});
+
+  return formattedDate;
 };
 
 module.exports = { getMemberDailyHabits };

--- a/src/services/habitService.js
+++ b/src/services/habitService.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const Habit = require('../models/Habit');
 const User = require('../models/User');
 const Group = require('../models/Group');
@@ -13,14 +14,49 @@ const checkGroupExists = (groupId) => Group.exists({ _id: groupId });
 
 const createNewHabit = async (habitData) => {
   const habit = new Habit(habitData);
+  const { creator: userId, sharedGroup: groupId } = habitData;
+
   await habit.save();
+
+  await User.findOneAndUpdate(
+    { _id: userId },
+    { $push: { habits: habit._id } },
+  );
+
+  if (groupId) {
+    await Group.findOneAndUpdate(
+      { _id: groupId },
+      { $push: { habits: habit._id } },
+    );
+  }
+
   return habit;
 };
 
 const updateExistingHabit = (habitId, updatedFields) =>
   Habit.findByIdAndUpdate(habitId, updatedFields, { new: true }).lean().exec();
 
-const deleteHabitById = (habitId) => Habit.findByIdAndDelete(habitId).exec();
+const deleteHabitById = async (habitId) => {
+  const { creator: userId, sharedGroup: groupId } = await getHabitById(habitId);
+
+  const result = await Habit.findByIdAndDelete(habitId).exec();
+
+  const objectHabitId = new mongoose.Types.ObjectId(habitId);
+
+  await User.findOneAndUpdate(
+    { _id: userId },
+    { $pull: { habits: objectHabitId } },
+  );
+
+  if (groupId) {
+    await Group.findOneAndUpdate(
+      { _id: groupId },
+      { $pull: { habits: objectHabitId } },
+    );
+  }
+
+  return result;
+};
 
 module.exports = {
   getHabitById,

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,6 +1,27 @@
 const User = require('../models/User');
+const dateToDay = require('../utils/dateToDay');
 
 const getNicknameByEmail = (email) =>
   User.findOne({ email }, 'nickname').lean().exec();
 
-module.exports = { getNicknameByEmail };
+const getUserDailyHabits = async (req, nickname) => {
+  const { date } = req.query;
+  const currentDay = dateToDay(date);
+
+  const user = await User.findOne({ nickname })
+    .populate({
+      path: 'habits',
+      match: {
+        doDay: { $in: [currentDay] },
+        habitStartDate: { $lte: date },
+        habitEndDate: { $gte: date },
+      },
+      select: '_id habitTitle startTime endTime',
+    })
+    .lean()
+    .exec();
+
+  return user ? user.habits : [];
+};
+
+module.exports = { getNicknameByEmail, getUserDailyHabits };

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -4,18 +4,23 @@ const dateToDay = require('../utils/dateToDay');
 const getNicknameByEmail = (email) =>
   User.findOne({ email }, 'nickname').lean().exec();
 
-const getUserDailyHabits = async (req, nickname) => {
+const getUserDailyHabits = async (req, nickname, sharedGroup = null) => {
   const { date } = req.query;
   const currentDay = dateToDay(date);
+  const matchConditions = {
+    doDay: { $in: [currentDay] },
+    habitStartDate: { $lte: date },
+    habitEndDate: { $gte: date },
+  };
+
+  if (sharedGroup) {
+    matchConditions.sharedGroup = sharedGroup;
+  }
 
   const user = await User.findOne({ nickname })
     .populate({
       path: 'habits',
-      match: {
-        doDay: { $in: [currentDay] },
-        habitStartDate: { $lte: date },
-        habitEndDate: { $gte: date },
-      },
+      match: matchConditions,
       select: '_id habitTitle startTime endTime',
     })
     .lean()

--- a/src/utils/dateToDay.js
+++ b/src/utils/dateToDay.js
@@ -1,0 +1,8 @@
+const dateToDay = (dateString) => {
+  const date = new Date(dateString);
+  const dayNames = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+  const dayOfWeek = date.getDay();
+  return dayNames[dayOfWeek];
+};
+
+module.exports = dateToDay;


### PR DESCRIPTION
📝 PR 목적
목록 컴포넌트에서 사용하는 유저별/그룹별 일간 습관 목록 조회

📑 작업 내용
- [x] 유저별 당일 습관 목록 조회
    - [x] 습관 id,  습관 제목, 시작시간, 종료시간

- 조회 성공
<img width="585" alt="스크린샷 2023-09-16 오후 4 25 29" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/fba43158-b448-4ca0-a493-4b6a29f8f584">

- 날짜 형식 오류
<img width="852" alt="스크린샷 2023-09-16 오후 4 26 35" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/82f85ae2-46a0-498e-92a3-8ee3bbcbc933">

- [x] 그룹에 속해 있는 멤버의 당일 습관 목록 조회
    - [x] {유저 닉네임: {습관 id,  습관 제목, 시작시간, 종료시간}}
    - [x] sharedgroup 컬럼 값이 그룹 id인 습관만 조회

- 조회 성공
<img width="876" alt="스크린샷 2023-09-16 오후 4 27 09" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/4df192bb-79c7-4c2d-8901-9ac78f3ec6d6">

- 날짜 형식 오류
<img width="845" alt="스크린샷 2023-09-16 오후 4 27 28" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/6404c961-9018-492e-bd74-0e9381667d27">


- [x] 습관 생성 시 유저, 그룹 습관 컬럼에 습관 id 추가
- [x] 액세스 토큰 검증 미들웨어 추가 (현재 미사용)

🚧 주의 사항
- 액세스 토큰 검증 미들웨어는 그룹 멤버가 아닌 유저가 그룹 api를 호출하는지 검증하기 위해 만들었으나, 현재 클라이언트에서 목록 조회 api 호출 시 액세스 토큰을 넘겨주지 않아 사용하지 않고 있습니다.
