### PR TITLE
그룹 관련 api

### DIFF
--- a/src/controllers/groupController.js
+++ b/src/controllers/groupController.js
@@ -1,4 +1,45 @@
+const Group = require('../models/Group');
 const groupService = require('../services/groupService');
+const handleError = require('../lib/handleError');
+const { ERRORS } = require('../lib/ERRORS');
+
+const generateGroup = async (req, res, next) => {
+  const { groupName, invitationCode } = req.body;
+
+  try {
+    const hasGroup = await Group.exists({ groupName }).lean().exec();
+    if (hasGroup) {
+      return handleError(res, ERRORS.GROUP_ALREADY_EXISTS);
+    }
+    // invitationCode 생성? 받아오기?
+
+    // members 에 요청한 멤버 추가 -> access token을 받아와서 유저id를 알아야 할 것 같음
+
+    const newGroupColums = {
+      groupName,
+      invitationCode,
+    };
+
+    const newGroup = new Group(newGroupColums);
+    await newGroup.save();
+
+    return res.status(201).json({ newGroup });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+const getGroup = async (req, res, next) => {
+  const { groupId } = req.params;
+
+  try {
+    const group = await Group.findById(groupId).lean().exec();
+
+    return res.status(200).json({ group });
+  } catch (error) {
+    return next(error);
+  }
+};
 
 const getGroupDailyHabitList = async (req, res, next) => {
   try {
@@ -12,4 +53,6 @@ const getGroupDailyHabitList = async (req, res, next) => {
 
 module.exports = {
   getGroupDailyHabitList,
+  getGroup,
+  generateGroup,
 };

--- a/src/controllers/habitController.js
+++ b/src/controllers/habitController.js
@@ -228,10 +228,6 @@ const subscribeWatcher = async (req, res, next) => {
 
     newApproval.profileImageUrl = member.profileImageUrl;
 
-    console.log(member);
-
-    console.log(newApproval);
-
     return res.status(200).json(newApproval);
   } catch (error) {
     return next(error);

--- a/src/lib/ERRORS.js
+++ b/src/lib/ERRORS.js
@@ -237,6 +237,10 @@ const NO_USER_PROVIDED = '유저정보가 비어 있습니다.';
 
 const STATUS_NOT_INVITE = '초대 알림외에는 api로 생성되지 않습니다.';
 
+// 그룹 검증 오류 메시지
+
+const GROUP_ALREADY_EXISTS = '이미 존재하는 그룹입니다.';
+
 module.exports.ERRORS = {
   INVALID_GROUP_NAME,
   INVALID_INVITATION_CODE,
@@ -300,4 +304,5 @@ module.exports.ERRORS = {
   IMAGE_UPLOAD_FAILED,
   NOT_SHARED_GROUP,
   ALREADY_SUBSCRIBED,
+  GROUP_ALREADY_EXISTS,
 };

--- a/src/lib/ERRORS.js
+++ b/src/lib/ERRORS.js
@@ -239,7 +239,10 @@ const STATUS_NOT_INVITE = '초대 알림외에는 api로 생성되지 않습니�
 
 // 그룹 검증 오류 메시지
 
-const GROUP_ALREADY_EXISTS = '이미 존재하는 그룹입니다.';
+const GROUP_ALREADY_EXISTS = {
+  STATUS_CODE: 400,
+  MESSAGE: '이미 존재하는 그룹입니다.',
+};
 
 module.exports.ERRORS = {
   INVALID_GROUP_NAME,

--- a/src/middlewares/validateGroup.js
+++ b/src/middlewares/validateGroup.js
@@ -1,5 +1,20 @@
-const { param, query } = require('express-validator');
+const { param, query, body } = require('express-validator');
 const { ERRORS } = require('../lib/ERRORS');
+
+const validateInvitation = [
+  body('groupName')
+    .isString()
+    .isLength({ min: 2, max: 15 })
+    .withMessage(ERRORS.INVALID_GROUP_NAME.MESSAGE),
+  body('invitationCode')
+    .isString()
+    .isLength({ min: 6, max: 6 })
+    .withMessage(ERRORS.INVALID_INVITATION_CODE.MESSAGE),
+];
+
+const validateGroupId = [
+  param('groupId').isMongoId().withMessage(ERRORS.INVALID_MONGO_ID),
+];
 
 const validateGetGroupHabitList = [
   param('groupId').isMongoId().withMessage(ERRORS.INVALID_MONGO_ID.MESSAGE),
@@ -11,4 +26,6 @@ const validateGetGroupHabitList = [
 
 module.exports = {
   validateGetGroupHabitList,
+  validateGroupId,
+  validateInvitation,
 };

--- a/src/middlewares/validateGroup.js
+++ b/src/middlewares/validateGroup.js
@@ -6,10 +6,6 @@ const validateInvitation = [
     .isString()
     .isLength({ min: 2, max: 15 })
     .withMessage(ERRORS.INVALID_GROUP_NAME.MESSAGE),
-  body('invitationCode')
-    .isString()
-    .isLength({ min: 6, max: 6 })
-    .withMessage(ERRORS.INVALID_INVITATION_CODE.MESSAGE),
 ];
 
 const validateGroupId = [

--- a/src/models/Group.js
+++ b/src/models/Group.js
@@ -13,14 +13,8 @@ const GroupSchema = new mongoose.Schema(
       required: true,
       unique: true,
     },
-    members: {
-      type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
-      default: [],
-    },
-    habits: {
-      type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Habit' }],
-      default: [],
-    },
+    members: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
+    habits: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Habit' }],
   },
   {
     timestamps: true,

--- a/src/models/Group.js
+++ b/src/models/Group.js
@@ -8,11 +8,6 @@ const GroupSchema = new mongoose.Schema(
       minlength: 2,
       maxlength: 15,
     },
-    invitationCode: {
-      type: String,
-      required: true,
-      unique: true,
-    },
     members: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
     habits: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Habit' }],
   },

--- a/src/models/Habit.js
+++ b/src/models/Habit.js
@@ -68,14 +68,6 @@ const HabitSchema = new mongoose.Schema(
     sharedGroup: { type: mongoose.Schema.Types.ObjectId, ref: 'Group' },
     habitImage: {
       type: String,
-      validate: {
-        validator(url) {
-          return /^(https:\/\/s3\.amazonaws\.com\/${bucket-name}\/).+/.test(
-            url,
-          );
-        },
-        message: (props) => `${props.value}${ERRORS.INVALID_S3_URL}`,
-      },
     },
     minApprovalCount: { type: Number, default: 0 },
     approvals: [

--- a/src/routes/group.js
+++ b/src/routes/group.js
@@ -7,6 +7,39 @@ const groupController = require('../controllers/groupController');
 const router = express.Router();
 
 /**
+ * 그룹 생성 API
+ * api/group
+ */
+router.post(
+  '/',
+  validateGroup.validateInvitation,
+  validateMiddleware,
+  groupController.generateGroup,
+);
+
+/**
+ * 그룹 조회 API
+ * api/group/:groupId
+ */
+router.get(
+  '/:groupId',
+  validateGroup.validateGroupId,
+  validateMiddleware,
+  groupController.getGroup,
+);
+
+/**
+ * 그룹 멤버 추가 API
+ * api/group/:groupId/members
+ */
+router.post(
+  '/:groupId/members',
+  validateGroup.validateGroupId,
+  validateMiddleware,
+  groupController.getGroup,
+);
+
+/**
  * 그룹별 일간 습관 목록 조회 API
  * api/group/:groupId/habitList?date=:date
  */


### PR DESCRIPTION
📝 PR 목적
그룹 조회, 생성 api 작성

📑 작업 내용

**그룹 조회 api**
- [x] groupid 검증

- 그룹 조회 성공
![그룹 조회 성공](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/6d6bb991-c5eb-439a-9491-54b121424e2a)

- 그룹 조회 실패
![그룹 조회 실패](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/0318c679-dbea-446b-9f7a-9dd39fa076e2)

**그룹 생성 api**
- [x] creatorId가 실제 유저인지 검증
- [x] 그룹 제목 중복 검증
![중복 그룹 생성 시도](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/d4f863e1-f396-4d41-9a69-94ff5f156ffb)

- [x] 그룹 생성 성공
![그룹 생성 성공1](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/a5f11aff-2635-48cf-80e0-461eff57688f)
![그룹 생성 성공2](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/176188f5-68cb-4f41-b3f4-5604803eeef0)
- 생성 유저 스키마에 그룹 추가
![생성된 그룹 생성자 스키마에 추가됨](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/098f0e1b-a08a-4fa8-96d3-96f6b3ba12ff)

🚧 주의 사항
- 그룹 생성 테스트하다가 클라이언트 <HabitList> 컴포넌트가 a 그룹 페이지에서 b 그룹 페이지로 이동할 때 a그룹 페이지에만 존재하는 유저가 선택된 상태로 b그룹 페이지로 이동하면 에러 나는걸 발견했습니다. 클라이언트 브랜치로 수정 올라갈 예정입니다.
- 그룹 스키마에서 초대 코드 제거, members, habits 스키마 객체 안에 배열있던거 수정했습니다
- 습관 스키마에서 잘못된 aws s3 url 검증 제거했습니다.
