### PR TITLE
Feature 인증 상태 수정 관련 api 작업

### DIFF
--- a/src/services/habitService.js
+++ b/src/services/habitService.js
@@ -52,16 +52,13 @@ const updateExistingHabit = async (habitId, fields) => {
   const updatedFields = { ...fields };
 
   if (updatedFields.approvalStatus && updatedFields.approvalId) {
-    await Habit.updateOne(
+    return Habit.updateOne(
       {
         _id: habitId,
         'approvals._id': new mongoose.Types.ObjectId(updatedFields.approvalId),
       },
       { $set: { 'approvals.$.status': updatedFields.approvalStatus } },
     );
-
-    delete updatedFields.approvalStatus;
-    delete updatedFields.approvalId;
   }
 
   return Habit.findByIdAndUpdate(habitId, updatedFields, { new: true })

--- a/src/services/habitService.js
+++ b/src/services/habitService.js
@@ -48,8 +48,26 @@ const createNewHabit = async (habitData) => {
   return habit;
 };
 
-const updateExistingHabit = (habitId, updatedFields) =>
-  Habit.findByIdAndUpdate(habitId, updatedFields, { new: true }).lean().exec();
+const updateExistingHabit = async (habitId, fields) => {
+  const updatedFields = { ...fields };
+
+  if (updatedFields.approvalStatus && updatedFields.approvalId) {
+    await Habit.updateOne(
+      {
+        _id: habitId,
+        'approvals._id': new mongoose.Types.ObjectId(updatedFields.approvalId),
+      },
+      { $set: { 'approvals.$.status': updatedFields.approvalStatus } },
+    );
+
+    delete updatedFields.approvalStatus;
+    delete updatedFields.approvalId;
+  }
+
+  return Habit.findByIdAndUpdate(habitId, updatedFields, { new: true })
+    .lean()
+    .exec();
+};
 
 const deleteHabitById = async (habitId) => {
   const { creator: userId, sharedGroup: groupId } = await getHabitById(habitId);


### PR DESCRIPTION
📝 PR 목적
습관을 승인하면 Habit.approvals의 배열내의 status 수정

📑 작업 내용
- 요청 body에 approvalStatus,  approvalId가 넘어오면 Habit.approvals의 배열내의 status만 수정함
  ![image](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133579214/8275432a-d412-4e56-bcbb-6981349f2d8f)
- 기존 습관 수정 테스트
  ![image](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133579214/c2229b3c-2cfc-4dac-a3df-21195a89ff06)

🚧 주의 사항

