### PR TITLE
Feature 기한별 습관 목록 조회 api

### DIFF
--- a/src/controllers/habitController.js
+++ b/src/controllers/habitController.js
@@ -21,6 +21,27 @@ const getHabit = async (req, res, next) => {
   }
 };
 
+const getPeriodicHabitsByUserId = async (req, res, next) => {
+  const { userId } = req.params;
+  const { startDate, endDate } = req.query;
+
+  try {
+    const habits = await habitService.getHabitsByDateRange(
+      userId,
+      startDate,
+      endDate,
+    );
+
+    if (!habits || habits.length === 0) {
+      return handleError(res, ERRORS.HABIT_NOT_FOUND);
+    }
+
+    return res.status(200).json(habits);
+  } catch (error) {
+    return next(error);
+  }
+};
+
 const createHabit = async (req, res, next) => {
   const {
     creator,
@@ -269,6 +290,7 @@ const unSubscribeWatcher = async (req, res, next) => {
 
 module.exports = {
   getHabit,
+  getPeriodicHabitsByUserId,
   createHabit,
   updateHabit,
   deleteHabit,

--- a/src/middlewares/validateHabit.js
+++ b/src/middlewares/validateHabit.js
@@ -4,6 +4,9 @@ const { ERRORS } = require('../lib/ERRORS');
 const isHabitId = () =>
   param('habitId').isMongoId().withMessage(ERRORS.INVALID_HABIT_ID);
 
+const isUserId = () =>
+  param('userId').isMongoId().withMessage(ERRORS.INVALID_MONGO_ID.MESSAGE);
+
 const isHabitTitle = (isRequired = true) =>
   body('habitTitle')
     .optional(!isRequired)
@@ -141,6 +144,8 @@ const patchRequest = [
 
 const deleteRequest = [isHabitId()];
 
+const getWeeklyHabitsRequest = [isUserId()];
+
 const subscribeHabitRequest = [isHabitId(), isWatcherId()];
 
 const unSubscribeHabitRequest = [isHabitId(), isWatcherIdonUrl()];
@@ -150,6 +155,7 @@ module.exports = {
   deleteRequest,
   getRequest,
   patchRequest,
+  getWeeklyHabitsRequest,
   subscribeHabitRequest,
   unSubscribeHabitRequest,
 };

--- a/src/middlewares/validateHabit.js
+++ b/src/middlewares/validateHabit.js
@@ -144,7 +144,7 @@ const patchRequest = [
 
 const deleteRequest = [isHabitId()];
 
-const getWeeklyHabitsRequest = [isUserId()];
+const getPeriodicHabitsByUserIdRequest = [isUserId()];
 
 const subscribeHabitRequest = [isHabitId(), isWatcherId()];
 
@@ -155,7 +155,7 @@ module.exports = {
   deleteRequest,
   getRequest,
   patchRequest,
-  getWeeklyHabitsRequest,
+  getPeriodicHabitsByUserIdRequest,
   subscribeHabitRequest,
   unSubscribeHabitRequest,
 };

--- a/src/routes/habit.js
+++ b/src/routes/habit.js
@@ -21,7 +21,7 @@ router.get(
 
 /**
  * 기한별 습관 조회 api
- * /api/habit/periodic/:userId?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
+ * /api/habit/periodic/:userId?startDate=:startDate&endDate=:endDate
  */
 router.get(
   '/periodic/:userId',

--- a/src/routes/habit.js
+++ b/src/routes/habit.js
@@ -20,6 +20,17 @@ router.get(
 );
 
 /**
+ * 기한별 습관 조회 api
+ * /api/habit/periodic/:userId?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
+ */
+router.get(
+  '/periodic/:userId',
+  validateHabit.getPeriodicHabitsByUserIdRequest,
+  validateMiddleware,
+  habitController.getPeriodicHabitsByUserId,
+);
+
+/**
  * 습관 생성 api
  * /api/habit
  */

--- a/src/services/habitService.js
+++ b/src/services/habitService.js
@@ -20,6 +20,16 @@ const getHabitById = (habitId) =>
     .lean()
     .exec();
 
+const getHabitsByDateRange = async (userId, startDate, endDate) =>
+  Habit.find({
+    creator: userId,
+    habitStartDate: { $lte: endDate },
+    habitEndDate: { $gte: startDate },
+  })
+    .select('doDay habitTitle startTime endTime')
+    .lean()
+    .exec();
+
 const checkUserExists = (userId) => User.exists({ _id: userId });
 
 const checkForDuplicateHabitTime = (conditions) =>
@@ -101,6 +111,7 @@ const updateHabitImageUrl = async (habitId, imageUrl) => {
 
 module.exports = {
   getHabitById,
+  getHabitsByDateRange,
   checkUserExists,
   checkForDuplicateHabitTime,
   checkGroupExists,


### PR DESCRIPTION
📝 PR 목적
Feature 기한별 습관 목록 조회 api

📑 작업 내용

/api/habit/periodic/:userId?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
- [x] 주간 계획표에 필요한 기한별 습관 목록 조회 api를 구현함

<img width="1353" alt="스크린샷 2023-09-21 오후 10 03 17" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133510836/325479a8-15f0-4267-a386-e61a6b6b41ce">

🚧 주의 사항
현재 이름이 좀 깁니다 혹시 좋은 의견 있으시면 부탁드릴게요
이후에 월별 등으로 확인하게 될 수도 있을 것 같아서 '주간' 말고 '기한별' 습관 목록 조회 api로 구현하였습니다.
클라이언트에서 작동 확인 완료했습니다.