### PR TITLE
Fix 알림 연동 api 수정

### DIFF
--- a/src/controllers/habitController.js
+++ b/src/controllers/habitController.js
@@ -133,7 +133,7 @@ const updateHabit = async (req, res, next) => {
       }
     }
 
-    // 와처 승인/거부 처리
+    /* 와처 승인/거부 처리 */
     if (approvalStatus) {
       const approveCount = habit.approvals.filter(
         (approval) => approval.status === 'approved',

--- a/src/controllers/habitController.js
+++ b/src/controllers/habitController.js
@@ -138,6 +138,7 @@ const updateHabit = async (req, res, next) => {
       const approveCount = habit.approvals.filter(
         (approval) => approval.status === 'approved',
       ).length;
+
       const rejectedCount = habit.approvals.filter(
         (approval) => approval.status === 'rejected',
       ).length;
@@ -147,6 +148,7 @@ const updateHabit = async (req, res, next) => {
         approveCount + 1 >= habit.minApprovalCount
       ) {
         updateFields.status = 'approvalSuccess';
+
         const notificationReq = {
           body: {
             content: `${habit.creator.nickname}님이 습관을 성공했습니다.
@@ -165,6 +167,7 @@ const updateHabit = async (req, res, next) => {
         rejectedCount + 1 > habit.approvals.length - habit.minApprovalCount
       ) {
         updateFields.status = 'approvalFailure';
+
         const notificationReq = {
           body: {
             content: `${habit.creator.nickname}님이 습관을 실패했습니다.

--- a/src/controllers/habitController.js
+++ b/src/controllers/habitController.js
@@ -144,7 +144,7 @@ const updateHabit = async (req, res, next) => {
 
       if (
         approvalStatus === 'approved' &&
-        approveCount + 1 >= minApprovalCount
+        approveCount + 1 >= habit.minApprovalCount
       ) {
         updateFields.status = 'approvalSuccess';
         const notificationReq = {
@@ -162,7 +162,7 @@ const updateHabit = async (req, res, next) => {
       }
       if (
         approvalStatus === 'rejected' &&
-        rejectedCount + 1 > habit.approvals.length - minApprovalCount
+        rejectedCount + 1 > habit.approvals.length - habit.minApprovalCount
       ) {
         updateFields.status = 'approvalFailure';
         const notificationReq = {

--- a/src/controllers/habitController.js
+++ b/src/controllers/habitController.js
@@ -4,6 +4,7 @@ const uploadImage = require('../services/aws/s3Service');
 const habitService = require('../services/habitService');
 const User = require('../models/User');
 const Habit = require('../models/Habit');
+const notificationService = require('../services/notificationService');
 
 const getHabit = async (req, res, next) => {
   const { habitId } = req.params;
@@ -84,6 +85,7 @@ const updateHabit = async (req, res, next) => {
     habitEndDate,
     minApprovalCount,
     sharedGroup,
+    approvalStatus,
   } = req.body;
 
   try {
@@ -131,6 +133,53 @@ const updateHabit = async (req, res, next) => {
       }
     }
 
+    // 와처 승인/거부 처리
+    if (approvalStatus) {
+      const approveCount = habit.approvals.filter(
+        (approval) => approval.status === 'approved',
+      ).length;
+      const rejectedCount = habit.approvals.filter(
+        (approval) => approval.status === 'rejected',
+      ).length;
+
+      if (
+        approvalStatus === 'approved' &&
+        approveCount + 1 >= minApprovalCount
+      ) {
+        updateFields.status = 'approvalSuccess';
+        const notificationReq = {
+          body: {
+            content: `${habit.creator.nickname}님이 습관을 성공했습니다.
+              ${habit.habitTitle}`,
+            from: habit.creator._id,
+            to: habit.creator._id,
+            status: 'success',
+            habitId,
+          },
+        };
+
+        await notificationService.saveNotification(notificationReq, res);
+      }
+      if (
+        approvalStatus === 'rejected' &&
+        rejectedCount + 1 > habit.approvals.length - minApprovalCount
+      ) {
+        updateFields.status = 'approvalFailure';
+        const notificationReq = {
+          body: {
+            content: `${habit.creator.nickname}님이 습관을 실패했습니다.
+              ${habit.habitTitle}`,
+            from: habit.creator._id,
+            to: habit.creator._id,
+            status: 'failure',
+            habitId,
+          },
+        };
+
+        await notificationService.saveNotification(notificationReq, res);
+      }
+    }
+
     const updatedHabit = await habitService.updateExistingHabit(
       habitId,
       updateFields,
@@ -175,7 +224,11 @@ const updateHabitImage = async (req, res, next) => {
         return handleError(res, ERRORS.IMAGE_UPLOAD_FAILED);
       }
 
-      const result = await habitService.updateHabitImageUrl(habitId, imageUrl);
+      const result = await habitService.updateHabitImageUrl(
+        habitId,
+        imageUrl,
+        res,
+      );
 
       if (!result) {
         return handleError(res, ERRORS.HABIT_NOT_FOUND);

--- a/src/models/Notification.js
+++ b/src/models/Notification.js
@@ -9,7 +9,9 @@ const NotificationSchema = new mongoose.Schema(
     from: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
     to: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
     createdAt: { type: Date, default: Date.now },
-    isNeedToSend: { type: Boolean, default: false },
+    isNeedToSend: { type: Boolean, default: true },
+    groupId: { type: mongoose.Schema.Types.ObjectId, ref: 'Group' },
+    habitId: { type: mongoose.Schema.Types.ObjectId, ref: 'Habit' },
     status: {
       type: String,
       enum: [

--- a/src/routes/notification.js
+++ b/src/routes/notification.js
@@ -8,6 +8,7 @@ const router = express.Router();
 
 /**
  * 알림 목록 조회 api
+ * api/notification/:userId
  */
 router.get(
   '/:userId',
@@ -18,6 +19,7 @@ router.get(
 
 /**
  * 알림 저장 api
+ * api/notification
  */
 router.post(
   '/',

--- a/src/services/habitService.js
+++ b/src/services/habitService.js
@@ -96,7 +96,7 @@ const updateHabitImageUrl = async (habitId, imageUrl, res) => {
   const habit = await getHabitById(habitId);
   const creatorNickname = habit.creator.nickname;
 
-  // 사진 인증했을때 지켜보는 사람에게 알림이 간다
+  /* 사진 인증했을때 지켜보는 사람에게 알림이 간다 */
   await Promise.all(
     habit.approvals.map(async (approval) => {
       const notificationReq = {
@@ -113,7 +113,8 @@ const updateHabitImageUrl = async (habitId, imageUrl, res) => {
       return notificationService.saveNotification(notificationReq, res);
     }),
   );
-  // sse로 접속한 유저들에게 실시간 알림이 간다
+
+  /* Todo: 접속한 유저들에게 실시간 알림 전송 필요 (SSE) */
 
   const result = await Habit.findByIdAndUpdate(habitId, {
     habitImage: imageUrl,

--- a/src/services/habitService.js
+++ b/src/services/habitService.js
@@ -53,13 +53,16 @@ const updateExistingHabit = async (habitId, fields) => {
   const updatedFields = { ...fields };
 
   if (updatedFields.approvalStatus && updatedFields.approvalId) {
-    return Habit.updateOne(
+    await Habit.updateOne(
       {
         _id: habitId,
         'approvals._id': new mongoose.Types.ObjectId(updatedFields.approvalId),
       },
       { $set: { 'approvals.$.status': updatedFields.approvalStatus } },
     );
+
+    delete updatedFields.approvalStatus;
+    delete updatedFields.approvalId;
   }
 
   return Habit.findByIdAndUpdate(habitId, updatedFields, { new: true })

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -1,5 +1,6 @@
 const { ERRORS } = require('../lib/ERRORS');
 const handleError = require('../lib/handleError');
+const Habit = require('../models/Habit');
 const Notification = require('../models/Notification');
 const User = require('../models/User');
 const getDateDiffFromToday = require('../utils/getDateDiffFromToday');
@@ -23,7 +24,7 @@ const getNotifications = async (userId) => {
 };
 
 const saveNotification = async (req, res) => {
-  const { to, status } = req.body;
+  const { to, status, habitId } = req.body;
 
   if (status !== 'invite') {
     return handleError(res, ERRORS.STATUS_NOT_INVITE);
@@ -40,6 +41,12 @@ const saveNotification = async (req, res) => {
 
   invitedUser.notifications.push(newNotification._id);
   await invitedUser.save();
+
+  if (habitId) {
+    const habit = await Habit.findById(habitId).exec();
+    habit.notifications.push(habitId);
+    await habit.save();
+  }
 
   return newNotification;
 };

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -26,9 +26,6 @@ const getNotifications = async (userId) => {
 const saveNotification = async (req, res) => {
   const { to, habitId } = req.body;
 
-  // if (status !== 'invite' || status !== 'approveRequest') {
-  //   return handleError(res, ERRORS.STATUS_NOT_INVITE);
-  // }
   const invitedUser = await User.findById(to).exec();
 
   if (!invitedUser) {

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -24,11 +24,11 @@ const getNotifications = async (userId) => {
 };
 
 const saveNotification = async (req, res) => {
-  const { to, status, habitId } = req.body;
+  const { to, habitId } = req.body;
 
-  if (status !== 'invite') {
-    return handleError(res, ERRORS.STATUS_NOT_INVITE);
-  }
+  // if (status !== 'invite' || status !== 'approveRequest') {
+  //   return handleError(res, ERRORS.STATUS_NOT_INVITE);
+  // }
   const invitedUser = await User.findById(to).exec();
 
   if (!invitedUser) {


### PR DESCRIPTION
📝 PR 목적
알림창에 생성된 알림을 가져오게 api 로직을 수정한다.

📑 작업 내용
- [x]  습관 수정 api
    - [x]  변경되는 컬럼에 따라 status 가 변경
    - [x]  status 가 변경되었을때 알림 생성해서 db에 저장
    - [x]  사진 인증했을때 지켜보는 사람에게 알림
![지켜보는사람에게 인증 요청 알림](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/753de5b0-fe45-40a0-a609-26e87641a692)

    - [x]  승인조건을 만족/실패했을때 상태 변경 및 습관 주인에게 알림
![인증 페이지 성공 및 알림](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/0280d032-6058-46a2-bb92-c476d39ef3ae)
![인증 페이지 실패 및 알림](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/ebc562f9-71ce-4b72-8fab-42357bdc2e57)


- [x]  알림 스키마 수정
    - [x]  그룹 아이디, 습관 아이디 추가
    - [x]  isneedtosend 디폴트 값 true
    - [x]  알림 api 연관된 부분 찾아서 수정

🚧 주의 사항
- 컴포넌트 작업은 컴포넌트 브랜치에 올라올 예정입니다.
- 사진 속 알림 메세지가 까만 것은 컴포넌트에서 작업 예정입니다.
