### PR TITLE
Feature 이전 습관 기록 저장

### DIFF
--- a/src/lib/dailyHabitsBackup/dailyHabitsBackup.js
+++ b/src/lib/dailyHabitsBackup/dailyHabitsBackup.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 const Habit = require('../../models/Habit');
 const HabitHistory = require('../../models/HabitHistory');
-const Notification = require('../../models/Notification');
 const getIncrementedTime = require('../updateHabitStatus/getIncrementedTime');
 const getKSTDateAndTime = require('../updateHabitStatus/getKSTDateAndTime');
 
@@ -45,25 +44,6 @@ const dailyHabitsBackup = async () => {
       await HabitHistory.insertMany(newHabits);
       console.log(
         `${newHabits.length} 개의 습관들이 습관 히스토리에 기록되었습니다.`,
-      );
-
-      // 저장 후 기존 습관 리셋 (상태, 승인여부), 분리예정
-      await Promise.all(
-        newHabits.map(async (newHabit) => {
-          await Habit.findByIdAndUpdate(newHabit.habitId, {
-            $set: {
-              status: 'notTimeYet',
-              'approvals.$[].status': 'undecided',
-              notifications: [],
-              habitImage: '',
-            },
-          });
-
-          await Notification.updateMany(
-            { habitId: newHabit.habitId },
-            { isNeedToSend: false },
-          );
-        }),
       );
     } else {
       console.log('기록할 습관이 없습니다.');

--- a/src/lib/dailyHabitsBackup/dailyHabitsBackup.js
+++ b/src/lib/dailyHabitsBackup/dailyHabitsBackup.js
@@ -1,0 +1,76 @@
+/* eslint-disable no-console */
+const Habit = require('../../models/Habit');
+const HabitHistory = require('../../models/HabitHistory');
+const Notification = require('../../models/Notification');
+const getIncrementedTime = require('../updateHabitStatus/getIncrementedTime');
+const getKSTDateAndTime = require('../updateHabitStatus/getKSTDateAndTime');
+
+const dayNames = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
+const dailyHabitsBackup = async () => {
+  const { day: today, time, todayDate } = getKSTDateAndTime();
+  const approveDoneTime = getIncrementedTime(time, 0, -6);
+  const yesterDay =
+    dayNames[(dayNames.findIndex((day) => day === today) + 6) % 7];
+
+  try {
+    const completedHabitToday = await Habit.find({
+      endTime: { $lte: approveDoneTime },
+      doDay: { $in: [today, yesterDay] },
+      habitStartDate: { $lte: todayDate },
+      habitEndDate: { $gt: todayDate },
+    })
+      .lean()
+      .exec();
+
+    const userIds = completedHabitToday.map((habit) => habit.creator);
+
+    const existingHabitIds = (
+      await HabitHistory.find({
+        date: todayDate,
+        userId: { $in: userIds },
+      }).distinct('habitId')
+    ).map((id) => id.toString());
+
+    const newHabits = completedHabitToday
+      .filter((habit) => !existingHabitIds.includes(habit._id.toString()))
+      .map((habit) => ({
+        date: todayDate,
+        userId: habit.creator,
+        habitId: habit._id,
+        habitDetails: habit,
+      }));
+
+    if (newHabits.length) {
+      await HabitHistory.insertMany(newHabits);
+      console.log(
+        `${newHabits.length} 개의 습관들이 습관 히스토리에 기록되었습니다.`,
+      );
+
+      // 저장 후 기존 습관 리셋 (상태, 승인여부), 분리예정
+      await Promise.all(
+        newHabits.map(async (newHabit) => {
+          await Habit.findByIdAndUpdate(newHabit.habitId, {
+            $set: {
+              status: 'notTimeYet',
+              'approvals.$[].status': 'undecided',
+              notifications: [],
+              habitImage: '',
+            },
+          });
+
+          await Notification.updateMany(
+            { habitId: newHabit.habitId },
+            { isNeedToSend: false },
+          );
+        }),
+      );
+    } else {
+      console.log('기록할 습관이 없습니다.');
+    }
+  } catch (error) {
+    console.error('습관 백업 중 문제가 발생했습니다.', error);
+  }
+};
+
+module.exports = dailyHabitsBackup;

--- a/src/lib/initializeHabit.js
+++ b/src/lib/initializeHabit.js
@@ -1,0 +1,24 @@
+const Habit = require('../models/Habit');
+const Notification = require('../models/Notification');
+
+const initializeHabit = async (habits) => {
+  await Promise.all(
+    habits.map(async (habit) => {
+      await Habit.findByIdAndUpdate(habit._id, {
+        $set: {
+          status: 'notTimeYet',
+          'approvals.$[].status': 'undecided',
+          notifications: [],
+          habitImage: '',
+        },
+      });
+
+      await Notification.updateMany(
+        { habitId: habit._id },
+        { isNeedToSend: false },
+      );
+    }),
+  );
+};
+
+module.exports = initializeHabit;

--- a/src/lib/updateHabitStatus/getIncrementedTime.js
+++ b/src/lib/updateHabitStatus/getIncrementedTime.js
@@ -7,7 +7,7 @@ const getIncrementedTime = (time, minutesToAdd = 0, hoursToAdd = 0) => {
     .split(':')
     .map((val) => String(val).padStart(2, '0'));
 
-  const adjustedTime = new Date(`${todayDate}T${hours}:${minutes}:00Z`);
+  const adjustedTime = new Date(`${todayDate}T${hours}:${minutes}:00+09:00`);
 
   adjustedTime.setHours(adjustedTime.getHours() + hoursToAdd);
   adjustedTime.setMinutes(adjustedTime.getMinutes() + minutesToAdd);

--- a/src/lib/updateHabitStatus/updateAllHabits.js
+++ b/src/lib/updateHabitStatus/updateAllHabits.js
@@ -7,8 +7,12 @@ const { day, time, todayDate } = getKSTDateAndTime();
 const updateAllHabits = async () => {
   await updateHabitStatus(
     {
-      status: 'success',
-      // 초기화 로직
+      status: { $in: ['approvalSuccess', 'expiredFailure', 'approvalFailure'] },
+      habitStartDate: { $lte: todayDate },
+      habitEndDate: { $gte: todayDate },
+      doDay: { $in: [day] },
+      startTime: { $lte: time },
+      endTime: { $gte: time },
     },
     'notTimeYet',
   );

--- a/src/lib/updateHabitStatus/updateAllHabits.js
+++ b/src/lib/updateHabitStatus/updateAllHabits.js
@@ -7,11 +7,20 @@ const { day, time, todayDate } = getKSTDateAndTime();
 const updateAllHabits = async () => {
   await updateHabitStatus(
     {
+      status: 'success',
+      // 초기화 로직
+    },
+    'notTimeYet',
+  );
+
+  await updateHabitStatus(
+    {
       status: 'notTimeYet',
       habitStartDate: { $lte: todayDate },
       habitEndDate: { $gte: todayDate },
       doDay: { $in: [day] },
       startTime: { $lte: time },
+      endTime: { $gte: time },
     },
     'inProgress',
   );

--- a/src/lib/updateHabitStatus/updateHabitStatus.js
+++ b/src/lib/updateHabitStatus/updateHabitStatus.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 /* 배치 확인용 console 사용 */
 const Habit = require('../../models/Habit');
+const initializeHabit = require('../initializeHabit');
 const handleExpiredFailureStatus = require('./handleExpiredFailureStatus');
 const sendNotificationsForStatus = require('./sendNotificationsForStatus');
 
@@ -19,6 +20,12 @@ const updateHabitStatus = async (query, newStatus) => {
     console.log(`${newStatus}로 업데이트할 습관이 없습니다.`);
 
     return;
+  }
+
+  if (
+    ['approvalSuccess', 'expiredFailure', 'approvalFailure'].includes(newStatus)
+  ) {
+    initializeHabit(habits);
   }
 
   if (newStatus === 'awaitingVerification') {

--- a/src/lib/updateHabitStatus/updateHabitStatus.js
+++ b/src/lib/updateHabitStatus/updateHabitStatus.js
@@ -22,10 +22,8 @@ const updateHabitStatus = async (query, newStatus) => {
     return;
   }
 
-  if (
-    ['approvalSuccess', 'expiredFailure', 'approvalFailure'].includes(newStatus)
-  ) {
-    initializeHabit(habits);
+  if (newStatus === 'notTimeYet') {
+    await initializeHabit(habits);
   }
 
   if (newStatus === 'awaitingVerification') {

--- a/src/models/HabitHistory.js
+++ b/src/models/HabitHistory.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose');
+const HabitSchema = require('./Habit').schema;
+
+const HabitHistorySchema = new mongoose.Schema(
+  {
+    date: {
+      type: String,
+      required: true,
+      validate: {
+        validator(v) {
+          return /^(\d{4})-(\d{2})-(\d{2})$/.test(v);
+        },
+        message: 'Invalid date format',
+      },
+    },
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    habitId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Habit',
+      required: true,
+    },
+    habitDetails: HabitSchema,
+  },
+  {
+    timestamps: true,
+  },
+);
+
+module.exports = mongoose.model('HabitHistory', HabitHistorySchema);

--- a/src/utils/cronJob.js
+++ b/src/utils/cronJob.js
@@ -2,8 +2,10 @@
 /* 배치 확인용 console 사용 */
 const { CronJob } = require('cron');
 const updateAllHabits = require('../lib/updateHabitStatus/updateAllHabits');
+const dailyHabitsBackup = require('../lib/dailyHabitsBackup/dailyHabitsBackup');
 
-const job = new CronJob('0 */5 * * * *', () => {
+// 습관 상태변경 및 알림 전송
+const job = new CronJob('0 */1 * * * *', () => {
   const currentTime = new Date().toLocaleString();
   console.log(`배치 실행 로그 - ${currentTime}`);
 
@@ -11,3 +13,13 @@ const job = new CronJob('0 */5 * * * *', () => {
 });
 
 job.start();
+
+// 일일 습관 백업
+const habitBackupBatch = new CronJob('*/10 * * * * *', () => {
+  const currentTime = new Date().toLocaleString();
+  console.log(`습관 백업 배치 실행 로그 - ${currentTime}`);
+
+  dailyHabitsBackup();
+});
+
+habitBackupBatch.start();

--- a/src/utils/cronJob.js
+++ b/src/utils/cronJob.js
@@ -5,7 +5,7 @@ const updateAllHabits = require('../lib/updateHabitStatus/updateAllHabits');
 const dailyHabitsBackup = require('../lib/dailyHabitsBackup/dailyHabitsBackup');
 
 // 습관 상태변경 및 알림 전송
-const job = new CronJob('0 */1 * * * *', () => {
+const job = new CronJob('0 */5 * * * *', () => {
   const currentTime = new Date().toLocaleString();
   console.log(`배치 실행 로그 - ${currentTime}`);
 
@@ -15,7 +15,7 @@ const job = new CronJob('0 */1 * * * *', () => {
 job.start();
 
 // 일일 습관 백업
-const habitBackupBatch = new CronJob('*/10 * * * * *', () => {
+const habitBackupBatch = new CronJob('0 0 */6 * * *', () => {
   const currentTime = new Date().toLocaleString();
   console.log(`습관 백업 배치 실행 로그 - ${currentTime}`);
 


### PR DESCRIPTION
📝 PR 목적
배치로 습관 히스토리를 저장해 기록을 남기고 데이터를 초기화하는 작업입니다.

📑 작업 내용
- [x] HabitHistory 스키마 생성
- [x] 6시간마다 습관 저장용 배치 수행
![데이터 백업](https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/5d256ca2-4dd1-4045-baa1-b9db1e2f2198)

- [x] 습관 상태 관리 배치에 초기화 로직 추가(상태, 승인 여부, 알림 초기화)

    이전
    <img width="739" alt="초기화 이전" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/7136d846-2560-45c9-9cb1-a849001daf45">

    이후
    <img width="576" alt="초기화 이후" src="https://github.com/Last-Survivors-3-8/Watcher-Habit-Server/assets/133353168/e3ad7f29-9060-4d3c-8f5a-44ad3f29c610">


🚧 주의 사항
- 저장 배치 실행 주기에 대해 의견있으시면 알려주세요.
- 다음 실행 전까지는 유저가 완료된 습관을 확인할 수 있게 습관 시작시간에 초기화됩니다.
